### PR TITLE
RKB-214 RHEL-07-021620 Configure the file integrity tool to use FIPS 140-2 cryptographic hashes for validating file and directory contents

### DIFF
--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -146,6 +146,22 @@
   tags:
       - RHEL-07-021610
 
+- block:
+      - name: "LOW | RHEL-07-021620 | PATCH | Configure the file integrity tool to use FIPS 140-2 cryptographic hashes for validating file and directory contents.  Gather offending lines"
+        shell: |
+          /usr/bin/awk '/^[^#]+=/ { split($0, p, "="); gsub(/ /, "", p[1]); gsub(/ /, "", p[2]); r[p[1]] = p[2]; } /^[^#=!@]/ && !/=/ { x=$2; for (v in r) { c = sprintf("(^|+| )%s(+| |$)", v); gsub(c, r[v], x); } if ($0) { if (x !~ /sha512/) { print $1; f++ } } } END { if (f) { print "fail" } else { print "pass" } }' /etc/aide.conf
+        register: rhel_07_021620_audit
+
+      - name: "LOW | RHEL-07-021620 | PATCH | Configure the file integrity tool to use FIPS 140-2 cryptographic hashes for validating file and directory contents.  Change to sha512 verify"
+        replace:
+          path: /etc/aide.conf
+          regexp: ^({{ item | regex_escape() }})(\s+)(.*)
+          replace: '\1\2\3+sha512'
+        with_items: "{{ rhel_07_021620_audit.stdout_lines }}"
+  when: rhel_07_021620
+  tags:
+      - RHEL-07-021620
+
 - name: "LOW | RHEL-07-040000 | PATCH | The operating system must limit the number of concurrent sessions to 10 for all accounts and/or account types."
   lineinfile:
       state: present

--- a/tasks/fix-cat3.yml
+++ b/tasks/fix-cat3.yml
@@ -130,13 +130,21 @@
   tags:
       - RHEL-07-021600
 
-- name: "LOW | RHEL-07-021610 | PATCH | The file integrity tool must be configured to verify extended attributes."
-  command: "true"
-  changed_when: no
+- block:
+      - name: "LOW | RHEL-07-021610 | PATCH | The file integrity tool must be configured to verify extended attributes.  Gather offending lines"
+        shell: |
+          /usr/bin/awk '/^[^#]+=/ { split($0, p, "="); gsub(/ /, "", p[1]); gsub(/ /, "", p[2]); r[p[1]] = p[2]; } /^[^#=!@]/ && !/=/ { x=$2; for (v in r) { c = sprintf("(^|+| )%s(+| |$)", v); gsub(c, r[v], x); } if ($0) { if (x !~ /xattrs/) { print $1; f++ } } }' /etc/aide.conf
+        register: rhel_07_021610_audit
+
+      - name: "LOW | RHEL-07-021610 | PATCH | The file integrity tool must be configured to verify extended attributes.  Change to xattrs verify"
+        replace:
+          path: /etc/aide.conf
+          regexp: ^({{ item | regex_escape() }})(\s+)(.*)
+          replace: '\1\2\3+xattrs'
+        with_items: "{{ rhel_07_021610_audit.stdout_lines }}"
   when: rhel_07_021610
   tags:
       - RHEL-07-021610
-      - notimplemented
 
 - name: "LOW | RHEL-07-040000 | PATCH | The operating system must limit the number of concurrent sessions to 10 for all accounts and/or account types."
   lineinfile:


### PR DESCRIPTION
RKB-214 RHEL-07-021620 Configure the file integrity tool to use FIPS 140-2 cryptographic hashes for validating file and directory contents

Please merge https://github.com/ampsight/RHEL7-STIG/pull/19 since this branch is based off that.  Once the ancestor is merged, this PR will simplify.