### PR TITLE
RKB-196 RHEL-07-010240 - Removes printing "No users found"

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -284,7 +284,7 @@
   block:
       - name: "MEDIUM | RHEL-07-010240 | AUDIT | Passwords must be restricted to a 24 hours/1 day minimum lifetime."
         shell: |
-          v1=$(/usr/bin/awk '/^UID_MIN/ {print $2}' /etc/login.defs);/usr/bin/awk -v "uidmin=${v1}" -F: 'FILENAME == "/etc/passwd" { if ($3 >= uidmin) users[$1] } FILENAME == "/etc/shadow" { if ($1 in users && $4 < 1) badusers[$1]; } END { if (length(badusers) > 0){ for (user in badusers) {print user} } else { print "No users found" } }' /etc/passwd /etc/shadow
+          v1=$(/usr/bin/awk '/^UID_MIN/ {print $2}' /etc/login.defs);/usr/bin/awk -v "uidmin=${v1}" -F: 'FILENAME == "/etc/passwd" { if ($3 >= uidmin) users[$1] } FILENAME == "/etc/shadow" { if ($1 in users && $4 < 1) badusers[$1]; } END { if (length(badusers) > 0){ for (user in badusers) {print user} } }' /etc/passwd /etc/shadow
         check_mode: no
         changed_when: no
         register: rhel_07_010240_audit


### PR DESCRIPTION
This output causes the playbook to fail.