### PR TITLE
030840

### DIFF
--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -8,7 +8,9 @@
       owner: root
       group: root
       mode: 0600
-      line: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}"
+      #line: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}"
+      line:"{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}\r\n-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change"
+
       state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
       trivial_audit: "-w {{ item.path }} -p x {{ rhel7stig_workaround_for_ssg_benchmark | ternary('', '-F auid!=4294967295 ') }}-k {{ item.key }}"

--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -8,9 +8,7 @@
       owner: root
       group: root
       mode: 0600
-      #line: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}"
-      line:"{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}\r\n-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change"
-
+          line:"{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}\r\n-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change"
       state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
       trivial_audit: "-w {{ item.path }} -p x {{ rhel7stig_workaround_for_ssg_benchmark | ternary('', '-F auid!=4294967295 ') }}-k {{ item.key }}"

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1406,7 +1406,6 @@
             group: root
             mode: 0600
             line: "-a always,exit -F path={{ item }} -F auid>=1000 -F auid!=4294967295 -k setuid/setgid"
-            
             state: present
         with_items: "{{ rhel_07_030360_audit.stdout_lines }}"
   when: rhel_07_030360

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1394,10 +1394,7 @@
             group: root
             mode: 0600
             line: "-a always,exit -F path={{ item }} -F auid>=1000 -F auid!=4294967295 -k setuid/setgid"
-            line: "-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid" 
-            line: "-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid"
-            line: "-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid"
-            line: "-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid"
+            
             state: present
         with_items: "{{ rhel_07_030360_audit.stdout_lines }}"
   when: rhel_07_030360

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1394,6 +1394,10 @@
             group: root
             mode: 0600
             line: "-a always,exit -F path={{ item }} -F auid>=1000 -F auid!=4294967295 -k setuid/setgid"
+            line: "-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid" 
+            line: "-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid"
+            line: "-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid"
+            line: "-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid"
             state: present
         with_items: "{{ rhel_07_030360_audit.stdout_lines }}"
   when: rhel_07_030360


### PR DESCRIPTION
Modified "line" statement in audit_command.yml 030840:

ine: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}\r\n-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change"
