### PR TITLE
Update fix-cat2.yml

### DIFF
--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1405,9 +1405,65 @@
             owner: root
             group: root
             mode: 0600
-            line: "-a always,exit -F path={{ item }} -F auid>=1000 -F auid!=4294967295 -k setuid/setgid"
+            line: "-a always,exit -F path={{ item }} -F auid>=1000 -F auid!=4294967295 -k setuid"
             state: present
         with_items: "{{ rhel_07_030360_audit.stdout_lines }}"
+        
+       - name: "MEDIUM | RHEL-07-030360 | All privileged function executions must be audited."
+        lineinfile:
+            path: "/etc/audit/rules.d/rhel7stig_suid_sgid_commands.rules"
+            create: yes
+            owner: root
+            group: root
+            mode: 0600
+            line: "-a always,exit -F path={{ item }} -F auid>=1000 -F auid!=4294967295 -k setuid"
+            state: present
+        with_items: "{{ rhel_07_030360_audit.stdout_lines }}"
+
+
+      - name: "MEDIUM | RHEL-07-030360 | All privileged function executions must be audited."
+        lineinfile:
+            path: "/etc/audit/rules.d/rhel7stig_suid_sgid_commands.rules"
+            create: yes
+            owner: root
+            group: root
+            mode: 0600
+            line: "-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid"
+            state: present
+        with_items: "{{ rhel_07_030360_audit.stdout_lines }}"
+
+      - name: "MEDIUM | RHEL-07-030360 | All privileged function executions must be audited."
+        lineinfile:
+            path: "/etc/audit/rules.d/rhel7stig_suid_sgid_commands.rules"
+            create: yes
+            owner: root
+            group: root
+            mode: 0600
+            line: "-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid"
+            state: present
+        with_items: "{{ rhel_07_030360_audit.stdout_lines }}"
+
+      - name: "MEDIUM | RHEL-07-030360 | All privileged function executions must be audited."
+        lineinfile:
+            path: "/etc/audit/rules.d/rhel7stig_suid_sgid_commands.rules"
+            create: yes
+            owner: root
+            group: root
+            mode: 0600
+            line: "-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid"
+            state: present
+        with_items: "{{ rhel_07_030360_audit.stdout_lines }}"
+
+      - name: "MEDIUM | RHEL-07-030360 | All privileged function executions must be audited."
+        lineinfile:
+            path: "/etc/audit/rules.d/rhel7stig_suid_sgid_commands.rules"
+            create: yes
+            owner: root
+            group: root
+            mode: 0600
+            line: "-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid"
+            state: present
+        with_items: "{{ rhel_07_030360_audit.stdout_lines }}" 
   when: rhel_07_030360
   tags:
       - RHEL-07-030360


### PR DESCRIPTION
Changed Fix-cat2.yml .
Configure the operating system to audit the execution of privileged functions.
Added the following lines to "/etc/audit/rules.d/audit.rules"

-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid
-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid
-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid
-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid