### PR TITLE
Anthony w/030840

### DIFF
--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -1,5 +1,5 @@
 ---
-#tasks/audit_command.yml
+# tasks/audit_command.yml
 
 - name: "MEDIUM | RHEL-07-{{ item.id }} | {{ audit_present | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.path | basename }} command must be audited."
   lineinfile:

--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -12,7 +12,7 @@
       state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
       normal_audit: "-a always,exit -F path={{ item.path }} {% if not item.no_perm_x_filter is defined or not item.no_perm_x_filter %}-F perm=x {% endif %}-F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
-      trivial_audit: "-w {{ item.path }} -p x -F auid!=4294967295 -k {{ item.key }}"
+      trivial_audit: "-w {{ item.path }} -p x {{ rhel7stig_workaround_for_ssg_benchmark | ternary('-F auid!=4294967295 ','') }}-k {{ item.key }}"
       audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd
 

--- a/tasks/audit_command.yml
+++ b/tasks/audit_command.yml
@@ -1,5 +1,5 @@
 ---
-# tasks/audit_command.yml
+#tasks/audit_command.yml
 
 - name: "MEDIUM | RHEL-07-{{ item.id }} | {{ audit_present | ternary('PATCH', 'REVERT') }} | All uses of the {{ item.path | basename }} command must be audited."
   lineinfile:
@@ -11,7 +11,8 @@
       line: "{{ item.trivial | default(false) | ternary(trivial_audit, normal_audit) }}"
       state: "{{ audit_present | ternary('present', 'absent') }}"
   vars:
-      trivial_audit: "-w {{ item.path }} -p x {{ rhel7stig_workaround_for_ssg_benchmark | ternary('', '-F auid!=4294967295 ') }}-k {{ item.key }}"
       normal_audit: "-a always,exit -F path={{ item.path }} {% if not item.no_perm_x_filter is defined or not item.no_perm_x_filter %}-F perm=x {% endif %}-F auid>=1000 -F auid!=4294967295 -k {{ item.key }}"
+      trivial_audit: "-w {{ item.path }} -p x -F auid!=4294967295 -k {{ item.key }}"
       audit_present: "{{ item.create | default(vars['rhel_07_' + item.id]) }}"
   notify: restart auditd
+

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -1680,7 +1680,7 @@
         no_perm_x_filter: true
       - id: "030840"
         path: "/usr/bin/kmod"
-        trivial: no
+        trivial: yes
         key: "module-change"
         no_perm_x_filter: true
   tags:


### PR DESCRIPTION
Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "insmod" command occur.

The following update was made to "/etc/audit/rules.d/audit.rules":
":-w /usr/bin/kmod -p x -F auid!=4294967295 -k module-change

Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
Audit records can be generated from various components within the information system (e.g., module or policy filter).

Satisfies: SRG-OS-000471-GPOS-00216, SRG-OS-000477-GPOS-00222
Policy Value

    Actual Value:

    The file "/etc/audit/audit.rules" does not contain "^[\s]*-w[\s]+/usr/bin/kmod[\s]+-p[\s]+x[\s]+-F[\s]+auid!=4294967295[\s]+-k[\s]+module-change"

 
